### PR TITLE
DX-101630: Add `hideSQLTablesListing` flag

### DIFF
--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -68,13 +68,15 @@ const std::string FlightSqlConnection::USE_SYSTEM_TRUST_STORE = "useSystemTrustS
 const std::string FlightSqlConnection::STRING_COLUMN_LENGTH = "StringColumnLength";
 const std::string FlightSqlConnection::USE_WIDE_CHAR = "UseWideChar";
 const std::string FlightSqlConnection::CHUNK_BUFFER_CAPACITY = "ChunkBufferCapacity";
+const std::string FlightSqlConnection::HIDE_SQL_TABLES_LISTING = "HideSQLTablesListing";
 
 const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::DSN, FlightSqlConnection::DRIVER, FlightSqlConnection::HOST, FlightSqlConnection::PORT,
     FlightSqlConnection::TOKEN, FlightSqlConnection::UID, FlightSqlConnection::USER_ID, FlightSqlConnection::PWD,
     FlightSqlConnection::USE_ENCRYPTION, FlightSqlConnection::TRUSTED_CERTS, FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
     FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION, FlightSqlConnection::STRING_COLUMN_LENGTH,
-    FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::CHUNK_BUFFER_CAPACITY};
+    FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::CHUNK_BUFFER_CAPACITY,
+    FlightSqlConnection::HIDE_SQL_TABLES_LISTING};
 
 namespace {
 
@@ -203,6 +205,7 @@ void FlightSqlConnection::PopulateMetadataSettings(const Connection::ConnPropert
   metadata_settings_.string_column_length_ = GetStringColumnLength(conn_property_map);
   metadata_settings_.use_wide_char_ = GetUseWideChar(conn_property_map);
   metadata_settings_.chunk_buffer_capacity_ = GetChunkBufferCapacity(conn_property_map);
+  metadata_settings_.hide_sql_tables_listing_ = GetHideSQLTablesListing(conn_property_map);
 }
 
 boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(const Connection::ConnPropertyMap &conn_property_map) {
@@ -243,6 +246,11 @@ size_t FlightSqlConnection::GetChunkBufferCapacity(const ConnPropertyMap &connPr
   }
 
   return default_value;
+}
+
+bool FlightSqlConnection::GetHideSQLTablesListing(const ConnPropertyMap &connPropertyMap) {
+  bool default_value = false;
+  return AsBool(connPropertyMap, FlightSqlConnection::HIDE_SQL_TABLES_LISTING).value_or(default_value);
 }
 
 const FlightCallOptions &

--- a/flight_sql/flight_sql_connection.h
+++ b/flight_sql/flight_sql_connection.h
@@ -62,6 +62,7 @@ public:
   static const std::string STRING_COLUMN_LENGTH;
   static const std::string USE_WIDE_CHAR;
   static const std::string CHUNK_BUFFER_CAPACITY;
+  static const std::string HIDE_SQL_TABLES_LISTING;
 
   explicit FlightSqlConnection(odbcabstraction::OdbcVersion odbc_version, const std::string &driver_version = "0.9.0.0");
 
@@ -107,6 +108,8 @@ public:
   bool GetUseWideChar(const ConnPropertyMap &connPropertyMap);
 
   size_t GetChunkBufferCapacity(const ConnPropertyMap &connPropertyMap);
+
+  bool GetHideSQLTablesListing(const ConnPropertyMap &connPropertyMap);
 };
 } // namespace flight_sql
 } // namespace driver

--- a/odbcabstraction/include/odbcabstraction/types.h
+++ b/odbcabstraction/include/odbcabstraction/types.h
@@ -167,6 +167,7 @@ struct MetadataSettings {
   boost::optional<int32_t> string_column_length_{boost::none};
   size_t chunk_buffer_capacity_;
   bool use_wide_char_;
+  bool hide_sql_tables_listing_;
 };
 
 } // namespace odbcabstraction


### PR DESCRIPTION
When this flag is set to `true` the driver will always return empty results when an ODBC API call is made to the `SQLTables` function.  Therefore avoiding the crash exhibited by MS Excel v16.95 when listing the available tables to be queried.

Full context in [DX-101630](https://dremio.atlassian.net/browse/DX-101630).