### PR TITLE
DX-97193: Add `UseExtendedFlightSQLBuffer` flag

### DIFF
--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -66,6 +66,7 @@ const std::string FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION = "disab
 const std::string FlightSqlConnection::TRUSTED_CERTS = "trustedCerts";
 const std::string FlightSqlConnection::USE_SYSTEM_TRUST_STORE = "useSystemTrustStore";
 const std::string FlightSqlConnection::STRING_COLUMN_LENGTH = "StringColumnLength";
+const std::string FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER = "UseExtendedFlightSQLBuffer";
 const std::string FlightSqlConnection::USE_WIDE_CHAR = "UseWideChar";
 const std::string FlightSqlConnection::CHUNK_BUFFER_CAPACITY = "ChunkBufferCapacity";
 const std::string FlightSqlConnection::HIDE_SQL_TABLES_LISTING = "HideSQLTablesListing";
@@ -75,7 +76,7 @@ const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::TOKEN, FlightSqlConnection::UID, FlightSqlConnection::USER_ID, FlightSqlConnection::PWD,
     FlightSqlConnection::USE_ENCRYPTION, FlightSqlConnection::TRUSTED_CERTS, FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
     FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION, FlightSqlConnection::STRING_COLUMN_LENGTH,
-    FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::CHUNK_BUFFER_CAPACITY,
+    FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER, FlightSqlConnection::CHUNK_BUFFER_CAPACITY,
     FlightSqlConnection::HIDE_SQL_TABLES_LISTING};
 
 namespace {
@@ -204,6 +205,7 @@ void FlightSqlConnection::Connect(const ConnPropertyMap &properties,
 void FlightSqlConnection::PopulateMetadataSettings(const Connection::ConnPropertyMap &conn_property_map) {
   metadata_settings_.string_column_length_ = GetStringColumnLength(conn_property_map);
   metadata_settings_.use_wide_char_ = GetUseWideChar(conn_property_map);
+  metadata_settings_.use_extended_flightsql_buffer_ = GetUseExtendedFlightSQLBuffer(conn_property_map);
   metadata_settings_.chunk_buffer_capacity_ = GetChunkBufferCapacity(conn_property_map);
   metadata_settings_.hide_sql_tables_listing_ = GetHideSQLTablesListing(conn_property_map);
 }
@@ -221,6 +223,11 @@ boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(const Connec
   }
 
   return boost::none;
+}
+
+bool FlightSqlConnection::GetUseExtendedFlightSQLBuffer(const ConnPropertyMap &connPropertyMap) {
+  bool default_value = false;
+  return AsBool(connPropertyMap, FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER).value_or(default_value);
 }
 
 bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap &connPropertyMap) {

--- a/flight_sql/flight_sql_connection.h
+++ b/flight_sql/flight_sql_connection.h
@@ -61,6 +61,7 @@ public:
   static const std::string USE_SYSTEM_TRUST_STORE;
   static const std::string STRING_COLUMN_LENGTH;
   static const std::string USE_WIDE_CHAR;
+  static const std::string USE_EXTENDED_FLIGHTSQL_BUFFER;
   static const std::string CHUNK_BUFFER_CAPACITY;
   static const std::string HIDE_SQL_TABLES_LISTING;
 
@@ -106,6 +107,8 @@ public:
   boost::optional<int32_t> GetStringColumnLength(const ConnPropertyMap &connPropertyMap);
 
   bool GetUseWideChar(const ConnPropertyMap &connPropertyMap);
+
+  bool GetUseExtendedFlightSQLBuffer(const ConnPropertyMap &connPropertyMap);
 
   size_t GetChunkBufferCapacity(const ConnPropertyMap &connPropertyMap);
 

--- a/flight_sql/flight_sql_result_set.cc
+++ b/flight_sql/flight_sql_result_set.cc
@@ -38,7 +38,12 @@ FlightSqlResultSet::FlightSqlResultSet(
     const odbcabstraction::MetadataSettings &metadata_settings)
     :
       metadata_settings_(metadata_settings),
-      chunk_buffer_(flight_sql_client, call_options, flight_info, metadata_settings_.chunk_buffer_capacity_),
+      chunk_buffer_(
+        flight_sql_client,
+        call_options,
+        flight_info,
+        metadata_settings_.chunk_buffer_capacity_,
+        metadata_settings_.use_extended_flightsql_buffer_),
       transformer_(transformer),
       metadata_(transformer ? new FlightSqlResultSetMetadata(transformer->GetTransformedSchema(),
                                                              metadata_settings_)

--- a/flight_sql/flight_sql_stream_chunk_buffer.cc
+++ b/flight_sql/flight_sql_stream_chunk_buffer.cc
@@ -16,7 +16,8 @@ using arrow::flight::FlightEndpoint;
 FlightStreamChunkBuffer::FlightStreamChunkBuffer(FlightSqlClient &flight_sql_client,
                                                  const arrow::flight::FlightCallOptions &call_options,
                                                  const std::shared_ptr<FlightInfo> &flight_info,
-                                                 size_t queue_capacity): queue_(queue_capacity) {
+                                                 size_t queue_capacity,
+                                                 bool use_extended_flightsql_buffer): queue_(queue_capacity, use_extended_flightsql_buffer) {
 
   // FIXME: Endpoint iteration should consider endpoints may be at different hosts
   for (const auto & endpoint : flight_info->endpoints()) {

--- a/flight_sql/flight_sql_stream_chunk_buffer.h
+++ b/flight_sql/flight_sql_stream_chunk_buffer.h
@@ -28,7 +28,8 @@ public:
   FlightStreamChunkBuffer(FlightSqlClient &flight_sql_client,
                           const arrow::flight::FlightCallOptions &call_options,
                           const std::shared_ptr<FlightInfo> &flight_info,
-                          size_t queue_capacity = 5);
+                          size_t queue_capacity = 5,
+                          bool use_extended_flightsql_buffer = false);
 
   ~FlightStreamChunkBuffer();
 

--- a/odbcabstraction/include/odbcabstraction/types.h
+++ b/odbcabstraction/include/odbcabstraction/types.h
@@ -167,6 +167,7 @@ struct MetadataSettings {
   boost::optional<int32_t> string_column_length_{boost::none};
   size_t chunk_buffer_capacity_;
   bool use_wide_char_;
+  bool use_extended_flightsql_buffer_;
   bool hide_sql_tables_listing_;
 };
 


### PR DESCRIPTION
When set to `true` (the default is `false`) it will enable an extended buffer to keep retrieving `FlightStreamChunk`s in a background thread while the client can't consume the early instances.

This provides a workaround for slow clients that take a lot of time to process query results, potentially having the Flight connection severed because the lack of activity, at the cost of an temporary increase in memory consumption.