### PR TITLE
DX-114056: Add configurable properties for HTTP/2.0 ping frames

### DIFF
--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -76,6 +76,7 @@ const std::string FlightSqlConnection::HIDE_SQL_TABLES_LISTING = "HideSQLTablesL
 const std::string FlightSqlConnection::SEND_PING_FRAME = "SendPingFrame";
 const std::string FlightSqlConnection::PING_FRAME_INTERVAL = "PingFrameInterval";
 const std::string FlightSqlConnection::PING_FRAME_TIMEOUT = "PingFrameTimeout";
+const std::string FlightSqlConnection::MAX_PINGS_WITHOUT_DATA = "MaxPingsWithoutData";
 
 const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::DSN, FlightSqlConnection::DRIVER, FlightSqlConnection::HOST, FlightSqlConnection::PORT,
@@ -84,7 +85,8 @@ const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION, FlightSqlConnection::STRING_COLUMN_LENGTH,
     FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::CHUNK_BUFFER_CAPACITY,
     FlightSqlConnection::HIDE_SQL_TABLES_LISTING, FlightSqlConnection::SEND_PING_FRAME,
-    FlightSqlConnection::PING_FRAME_INTERVAL, FlightSqlConnection::PING_FRAME_TIMEOUT};
+    FlightSqlConnection::PING_FRAME_INTERVAL, FlightSqlConnection::PING_FRAME_TIMEOUT,
+    FlightSqlConnection::MAX_PINGS_WITHOUT_DATA};
 
 namespace {
 
@@ -141,7 +143,8 @@ const std::set<std::string, odbcabstraction::CaseInsensitiveComparator> BUILT_IN
     FlightSqlConnection::USE_WIDE_CHAR,
     FlightSqlConnection::SEND_PING_FRAME,
     FlightSqlConnection::PING_FRAME_INTERVAL,
-    FlightSqlConnection::PING_FRAME_TIMEOUT
+    FlightSqlConnection::PING_FRAME_TIMEOUT,
+    FlightSqlConnection::MAX_PINGS_WITHOUT_DATA
 };
 
 Connection::ConnPropertyMap::const_iterator
@@ -292,6 +295,17 @@ int FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connProperty
   }
 }
 
+int FlightSqlConnection::GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap) {
+  const int min_max_pings_without_data = 0;
+  const int default_max_pings_without_data = 0;
+
+  try {
+    return AsInt32(min_max_pings_without_data, connPropertyMap, FlightSqlConnection::MAX_PINGS_WITHOUT_DATA).value_or(default_max_pings_without_data);
+  } catch (const std::exception& e) {
+    return default_max_pings_without_data;
+  }
+}
+
 const FlightCallOptions &
 FlightSqlConnection::PopulateCallOptions(const ConnPropertyMap &props) {
   // Set CONNECTION_TIMEOUT attribute or LOGIN_TIMEOUT depending on if this
@@ -341,6 +355,7 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
   if (send_ping_frame) {
     int ping_interval = GetPingFrameInterval(properties);
     int ping_timeout = GetPingFrameTimeout(properties);
+    int max_pings_without_data = GetMaxPingsWithoutData(properties);
     #ifdef __APPLE__
     //os_log(OS_LOG_DEFAULT, "FlightSQL Connection: Enabling gRPC keepalive with interval %d and timeout %d", ping_interval, ping_timeout);
     #endif
@@ -351,6 +366,7 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
     // TODO: was unable to build with the macros, so using string literals for now
     options.generic_options.emplace_back("grpc.keepalive_time_ms", ping_interval);
     options.generic_options.emplace_back("grpc.keepalive_timeout_ms", ping_timeout);
+    options.generic_options.emplace_back("grpc.http2.max_pings_without_data", max_pings_without_data);
   } else {
     #ifdef __APPLE__
     //os_log(OS_LOG_DEFAULT, "FlightSQL Connection: Not activating gRPC keepalive");

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -264,13 +264,13 @@ bool FlightSqlConnection::GetHideSQLTablesListing(const ConnPropertyMap &connPro
 }
 
 bool FlightSqlConnection::GetSendPingFrame(const ConnPropertyMap &connPropertyMap) {
-  bool default_value = true;
+  bool default_value = false;
   return AsBool(connPropertyMap, FlightSqlConnection::SEND_PING_FRAME).value_or(default_value);
 }
 
 int FlightSqlConnection::GetPingFrameInterval(const ConnPropertyMap &connPropertyMap) {
-  const int min_ping_frame_interval = 1;
-  const int default_ping_frame_interval = 200000;
+  const int min_ping_frame_interval = 1000;
+  const int default_ping_frame_interval = 7200000;
 
   try {
     return AsInt32(min_ping_frame_interval, connPropertyMap, FlightSqlConnection::PING_FRAME_INTERVAL).value_or(default_ping_frame_interval);
@@ -281,8 +281,8 @@ int FlightSqlConnection::GetPingFrameInterval(const ConnPropertyMap &connPropert
 }
 
 int FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap) {
-  const int min_ping_frame_timeout = 1;
-  const int default_ping_frame_timeout = 2000000;
+  const int min_ping_frame_timeout = 1000;
+  const int default_ping_frame_timeout = 20000;
 
   try {
     return AsInt32(min_ping_frame_timeout, connPropertyMap, FlightSqlConnection::PING_FRAME_TIMEOUT).value_or(default_ping_frame_timeout);
@@ -366,7 +366,7 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
     if (properties.end() != prop_iter) {
       options.override_hostname = prop_iter->second;
     }
-
+    
     if (ssl_config->shouldDisableCertificateVerification()) {
       options.disable_server_verification = ssl_config->shouldDisableCertificateVerification();
     } else {

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -29,6 +29,10 @@
 
 #include "system_trust_store.h"
 
+#ifdef __APPLE__
+#include <os/log.h>
+#endif
+
 #ifndef NI_MAXHOST
 #define NI_MAXHOST 1025
 #endif
@@ -69,6 +73,9 @@ const std::string FlightSqlConnection::STRING_COLUMN_LENGTH = "StringColumnLengt
 const std::string FlightSqlConnection::USE_WIDE_CHAR = "UseWideChar";
 const std::string FlightSqlConnection::CHUNK_BUFFER_CAPACITY = "ChunkBufferCapacity";
 const std::string FlightSqlConnection::HIDE_SQL_TABLES_LISTING = "HideSQLTablesListing";
+const std::string FlightSqlConnection::SEND_PING_FRAME = "SendPingFrame";
+const std::string FlightSqlConnection::PING_FRAME_INTERVAL = "PingFrameInterval";
+const std::string FlightSqlConnection::PING_FRAME_TIMEOUT = "PingFrameTimeout";
 
 const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::DSN, FlightSqlConnection::DRIVER, FlightSqlConnection::HOST, FlightSqlConnection::PORT,
@@ -76,7 +83,8 @@ const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::USE_ENCRYPTION, FlightSqlConnection::TRUSTED_CERTS, FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
     FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION, FlightSqlConnection::STRING_COLUMN_LENGTH,
     FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::CHUNK_BUFFER_CAPACITY,
-    FlightSqlConnection::HIDE_SQL_TABLES_LISTING};
+    FlightSqlConnection::HIDE_SQL_TABLES_LISTING, FlightSqlConnection::SEND_PING_FRAME,
+    FlightSqlConnection::PING_FRAME_INTERVAL, FlightSqlConnection::PING_FRAME_TIMEOUT};
 
 namespace {
 
@@ -130,7 +138,10 @@ const std::set<std::string, odbcabstraction::CaseInsensitiveComparator> BUILT_IN
     FlightSqlConnection::TRUSTED_CERTS,
     FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
     FlightSqlConnection::STRING_COLUMN_LENGTH,
-    FlightSqlConnection::USE_WIDE_CHAR
+    FlightSqlConnection::USE_WIDE_CHAR,
+    FlightSqlConnection::SEND_PING_FRAME,
+    FlightSqlConnection::PING_FRAME_INTERVAL,
+    FlightSqlConnection::PING_FRAME_TIMEOUT
 };
 
 Connection::ConnPropertyMap::const_iterator
@@ -253,6 +264,34 @@ bool FlightSqlConnection::GetHideSQLTablesListing(const ConnPropertyMap &connPro
   return AsBool(connPropertyMap, FlightSqlConnection::HIDE_SQL_TABLES_LISTING).value_or(default_value);
 }
 
+bool FlightSqlConnection::GetSendPingFrame(const ConnPropertyMap &connPropertyMap) {
+  bool default_value = true;
+  return AsBool(connPropertyMap, FlightSqlConnection::SEND_PING_FRAME).value_or(default_value);
+}
+
+int FlightSqlConnection::GetPingFrameInterval(const ConnPropertyMap &connPropertyMap) {
+  const int min_ping_frame_interval = 1;
+  const int default_ping_frame_interval = 200000;
+
+  try {
+    return AsInt32(min_ping_frame_interval, connPropertyMap, FlightSqlConnection::PING_FRAME_INTERVAL).value_or(default_ping_frame_interval);
+  } catch (const std::exception& e) {
+    return default_ping_frame_interval;
+  }
+
+}
+
+int FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap) {
+  const int min_ping_frame_timeout = 1;
+  const int default_ping_frame_timeout = 2000000;
+
+  try {
+    return AsInt32(min_ping_frame_timeout, connPropertyMap, FlightSqlConnection::PING_FRAME_TIMEOUT).value_or(default_ping_frame_timeout);
+  } catch (const std::exception& e) {
+    return default_ping_frame_timeout;
+  }
+}
+
 const FlightCallOptions &
 FlightSqlConnection::PopulateCallOptions(const ConnPropertyMap &props) {
   // Set CONNECTION_TIMEOUT attribute or LOGIN_TIMEOUT depending on if this
@@ -297,12 +336,33 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
   // Persist state information using cookies if the FlightProducer supports it.
   options.middleware.push_back(arrow::flight::GetCookieFactory());
 
+  // Configure gRPC keepalive (HTTP/2 ping frames) if enabled
+  bool send_ping_frame = GetSendPingFrame(properties);
+  if (send_ping_frame) {
+    int ping_interval = GetPingFrameInterval(properties);
+    int ping_timeout = GetPingFrameTimeout(properties);
+    #ifdef __APPLE__
+    //os_log(OS_LOG_DEFAULT, "FlightSQL Connection: Enabling gRPC keepalive with interval %d and timeout %d", ping_interval, ping_timeout);
+    #endif
+
+
+    // Set gRPC channel arguments for keepalive
+    // See https://arrow.apache.org/cookbook/cpp/flight.html#setting-grpc-client-options
+    // TODO: was unable to build with the macros, so using string literals for now
+    options.generic_options.emplace_back("grpc.keepalive_time_ms", ping_interval);
+    options.generic_options.emplace_back("grpc.keepalive_timeout_ms", ping_timeout);
+  } else {
+    #ifdef __APPLE__
+    //os_log(OS_LOG_DEFAULT, "FlightSQL Connection: Not activating gRPC keepalive");
+    #endif
+  }
+
   if (ssl_config->useEncryption()) {
     auto prop_iter = properties.find(HOST);
     if (properties.end() != prop_iter) {
       options.override_hostname = prop_iter->second;
     }
-    
+
     if (ssl_config->shouldDisableCertificateVerification()) {
       options.disable_server_verification = ssl_config->shouldDisableCertificateVerification();
     } else {

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -268,37 +268,33 @@ bool FlightSqlConnection::GetSendPingFrame(const ConnPropertyMap &connPropertyMa
   return AsBool(connPropertyMap, FlightSqlConnection::SEND_PING_FRAME).value_or(default_value);
 }
 
-int FlightSqlConnection::GetPingFrameInterval(const ConnPropertyMap &connPropertyMap) {
+boost::optional<int> FlightSqlConnection::GetPingFrameInterval(const ConnPropertyMap &connPropertyMap) {
   const int min_ping_frame_interval = 1000;
-  const int default_ping_frame_interval = 7200000;
 
   try {
-    return AsInt32(min_ping_frame_interval, connPropertyMap, FlightSqlConnection::PING_FRAME_INTERVAL).value_or(default_ping_frame_interval);
+    return AsInt32(min_ping_frame_interval, connPropertyMap, FlightSqlConnection::PING_FRAME_INTERVAL);
   } catch (const std::exception& e) {
-    return default_ping_frame_interval;
+    return boost::none;
   }
-
 }
 
-int FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap) {
+boost::optional<int> FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap) {
   const int min_ping_frame_timeout = 1000;
-  const int default_ping_frame_timeout = 20000;
 
   try {
-    return AsInt32(min_ping_frame_timeout, connPropertyMap, FlightSqlConnection::PING_FRAME_TIMEOUT).value_or(default_ping_frame_timeout);
+    return AsInt32(min_ping_frame_timeout, connPropertyMap, FlightSqlConnection::PING_FRAME_TIMEOUT);
   } catch (const std::exception& e) {
-    return default_ping_frame_timeout;
+    return boost::none;
   }
 }
 
-int FlightSqlConnection::GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap) {
+boost::optional<int> FlightSqlConnection::GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap) {
   const int min_max_pings_without_data = 0;
-  const int default_max_pings_without_data = 2;
 
   try {
-    return AsInt32(min_max_pings_without_data, connPropertyMap, FlightSqlConnection::MAX_PINGS_WITHOUT_DATA).value_or(default_max_pings_without_data);
+    return AsInt32(min_max_pings_without_data, connPropertyMap, FlightSqlConnection::MAX_PINGS_WITHOUT_DATA);
   } catch (const std::exception& e) {
-    return default_max_pings_without_data;
+    return boost::none;
   }
 }
 
@@ -349,16 +345,18 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
   // Configure gRPC keepalive (HTTP/2 ping frames) if enabled
   bool send_ping_frame = GetSendPingFrame(properties);
   if (send_ping_frame) {
-    int ping_interval = GetPingFrameInterval(properties);
-    int ping_timeout = GetPingFrameTimeout(properties);
-    int max_pings_without_data = GetMaxPingsWithoutData(properties);
-
-    // Set gRPC channel arguments for keepalive
+    // Set gRPC channel arguments for keepalive only if explicitly configured
     // See https://arrow.apache.org/cookbook/cpp/flight.html#setting-grpc-client-options
     // TODO: was unable to build with the macros, so using string literals for now
-    options.generic_options.emplace_back("grpc.keepalive_time_ms", ping_interval);
-    options.generic_options.emplace_back("grpc.keepalive_timeout_ms", ping_timeout);
-    options.generic_options.emplace_back("grpc.http2.max_pings_without_data", max_pings_without_data);
+    if (boost::optional<int> ping_interval = GetPingFrameInterval(properties)) {
+      options.generic_options.emplace_back("grpc.keepalive_time_ms", *ping_interval);
+    }
+    if (boost::optional<int> ping_timeout = GetPingFrameTimeout(properties)) {
+      options.generic_options.emplace_back("grpc.keepalive_timeout_ms", *ping_timeout);
+    }
+    if (boost::optional<int> max_pings_without_data = GetMaxPingsWithoutData(properties)) {
+      options.generic_options.emplace_back("grpc.http2.max_pings_without_data", *max_pings_without_data);
+    }
   }
 
   if (ssl_config->useEncryption()) {

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -29,10 +29,6 @@
 
 #include "system_trust_store.h"
 
-#ifdef __APPLE__
-#include <os/log.h>
-#endif
-
 #ifndef NI_MAXHOST
 #define NI_MAXHOST 1025
 #endif
@@ -356,10 +352,6 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
     int ping_interval = GetPingFrameInterval(properties);
     int ping_timeout = GetPingFrameTimeout(properties);
     int max_pings_without_data = GetMaxPingsWithoutData(properties);
-    #ifdef __APPLE__
-    //os_log(OS_LOG_DEFAULT, "FlightSQL Connection: Enabling gRPC keepalive with interval %d and timeout %d", ping_interval, ping_timeout);
-    #endif
-
 
     // Set gRPC channel arguments for keepalive
     // See https://arrow.apache.org/cookbook/cpp/flight.html#setting-grpc-client-options
@@ -367,10 +359,8 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
     options.generic_options.emplace_back("grpc.keepalive_time_ms", ping_interval);
     options.generic_options.emplace_back("grpc.keepalive_timeout_ms", ping_timeout);
     options.generic_options.emplace_back("grpc.http2.max_pings_without_data", max_pings_without_data);
-  } else {
-    #ifdef __APPLE__
-    //os_log(OS_LOG_DEFAULT, "FlightSQL Connection: Not activating gRPC keepalive");
-    #endif
+  }
+
   }
 
   if (ssl_config->useEncryption()) {

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -293,7 +293,7 @@ int FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connProperty
 
 int FlightSqlConnection::GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap) {
   const int min_max_pings_without_data = 0;
-  const int default_max_pings_without_data = 0;
+  const int default_max_pings_without_data = 2;
 
   try {
     return AsInt32(min_max_pings_without_data, connPropertyMap, FlightSqlConnection::MAX_PINGS_WITHOUT_DATA).value_or(default_max_pings_without_data);

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -361,8 +361,6 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
     options.generic_options.emplace_back("grpc.http2.max_pings_without_data", max_pings_without_data);
   }
 
-  }
-
   if (ssl_config->useEncryption()) {
     auto prop_iter = properties.find(HOST);
     if (properties.end() != prop_iter) {

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -71,8 +71,8 @@ const std::string FlightSqlConnection::USE_WIDE_CHAR = "UseWideChar";
 const std::string FlightSqlConnection::CHUNK_BUFFER_CAPACITY = "ChunkBufferCapacity";
 const std::string FlightSqlConnection::HIDE_SQL_TABLES_LISTING = "HideSQLTablesListing";
 const std::string FlightSqlConnection::SEND_PING_FRAME = "SendPingFrame";
-const std::string FlightSqlConnection::PING_FRAME_INTERVAL = "PingFrameInterval";
-const std::string FlightSqlConnection::PING_FRAME_TIMEOUT = "PingFrameTimeout";
+const std::string FlightSqlConnection::PING_FRAME_INTERVAL_MS = "PingFrameIntervalMilliseconds";
+const std::string FlightSqlConnection::PING_FRAME_TIMEOUT_MS = "PingFrameTimeoutMilliseconds";
 const std::string FlightSqlConnection::MAX_PINGS_WITHOUT_DATA = "MaxPingsWithoutData";
 
 const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
@@ -82,7 +82,7 @@ const std::vector<std::string> FlightSqlConnection::ALL_KEYS = {
     FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION, FlightSqlConnection::STRING_COLUMN_LENGTH,
     FlightSqlConnection::USE_WIDE_CHAR, FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER, FlightSqlConnection::CHUNK_BUFFER_CAPACITY,
     FlightSqlConnection::HIDE_SQL_TABLES_LISTING, FlightSqlConnection::SEND_PING_FRAME,
-    FlightSqlConnection::PING_FRAME_INTERVAL, FlightSqlConnection::PING_FRAME_TIMEOUT,
+    FlightSqlConnection::PING_FRAME_INTERVAL_MS, FlightSqlConnection::PING_FRAME_TIMEOUT_MS,
     FlightSqlConnection::MAX_PINGS_WITHOUT_DATA};
 
 namespace {
@@ -140,8 +140,8 @@ const std::set<std::string, odbcabstraction::CaseInsensitiveComparator> BUILT_IN
     FlightSqlConnection::USE_WIDE_CHAR,
     FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER,
     FlightSqlConnection::SEND_PING_FRAME,
-    FlightSqlConnection::PING_FRAME_INTERVAL,
-    FlightSqlConnection::PING_FRAME_TIMEOUT,
+    FlightSqlConnection::PING_FRAME_INTERVAL_MS,
+    FlightSqlConnection::PING_FRAME_TIMEOUT_MS,
     FlightSqlConnection::MAX_PINGS_WITHOUT_DATA
 };
 
@@ -276,21 +276,21 @@ bool FlightSqlConnection::GetSendPingFrame(const ConnPropertyMap &connPropertyMa
   return AsBool(connPropertyMap, FlightSqlConnection::SEND_PING_FRAME).value_or(default_value);
 }
 
-boost::optional<int> FlightSqlConnection::GetPingFrameInterval(const ConnPropertyMap &connPropertyMap) {
+boost::optional<int> FlightSqlConnection::GetPingFrameIntervalMilliseconds(const ConnPropertyMap &connPropertyMap) {
   const int min_ping_frame_interval = 1000;
 
   try {
-    return AsInt32(min_ping_frame_interval, connPropertyMap, FlightSqlConnection::PING_FRAME_INTERVAL);
+    return AsInt32(min_ping_frame_interval, connPropertyMap, FlightSqlConnection::PING_FRAME_INTERVAL_MS);
   } catch (const std::exception& e) {
     return boost::none;
   }
 }
 
-boost::optional<int> FlightSqlConnection::GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap) {
+boost::optional<int> FlightSqlConnection::GetPingFrameTimeoutMilliseconds(const ConnPropertyMap &connPropertyMap) {
   const int min_ping_frame_timeout = 1000;
 
   try {
-    return AsInt32(min_ping_frame_timeout, connPropertyMap, FlightSqlConnection::PING_FRAME_TIMEOUT);
+    return AsInt32(min_ping_frame_timeout, connPropertyMap, FlightSqlConnection::PING_FRAME_TIMEOUT_MS);
   } catch (const std::exception& e) {
     return boost::none;
   }
@@ -356,10 +356,10 @@ FlightSqlConnection::BuildFlightClientOptions(const ConnPropertyMap &properties,
     // Set gRPC channel arguments for keepalive only if explicitly configured
     // See https://arrow.apache.org/cookbook/cpp/flight.html#setting-grpc-client-options
     // TODO: was unable to build with the macros, so using string literals for now
-    if (boost::optional<int> ping_interval = GetPingFrameInterval(properties)) {
+    if (boost::optional<int> ping_interval = GetPingFrameIntervalMilliseconds(properties)) {
       options.generic_options.emplace_back("grpc.keepalive_time_ms", *ping_interval);
     }
-    if (boost::optional<int> ping_timeout = GetPingFrameTimeout(properties)) {
+    if (boost::optional<int> ping_timeout = GetPingFrameTimeoutMilliseconds(properties)) {
       options.generic_options.emplace_back("grpc.keepalive_timeout_ms", *ping_timeout);
     }
     if (boost::optional<int> max_pings_without_data = GetMaxPingsWithoutData(properties)) {

--- a/flight_sql/flight_sql_connection.cc
+++ b/flight_sql/flight_sql_connection.cc
@@ -138,7 +138,7 @@ const std::set<std::string, odbcabstraction::CaseInsensitiveComparator> BUILT_IN
     FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
     FlightSqlConnection::STRING_COLUMN_LENGTH,
     FlightSqlConnection::USE_WIDE_CHAR,
-    FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER
+    FlightSqlConnection::USE_EXTENDED_FLIGHTSQL_BUFFER,
     FlightSqlConnection::SEND_PING_FRAME,
     FlightSqlConnection::PING_FRAME_INTERVAL,
     FlightSqlConnection::PING_FRAME_TIMEOUT,

--- a/flight_sql/flight_sql_connection.h
+++ b/flight_sql/flight_sql_connection.h
@@ -66,6 +66,7 @@ public:
   static const std::string SEND_PING_FRAME;
   static const std::string PING_FRAME_INTERVAL;
   static const std::string PING_FRAME_TIMEOUT;
+  static const std::string MAX_PINGS_WITHOUT_DATA;
 
   explicit FlightSqlConnection(odbcabstraction::OdbcVersion odbc_version, const std::string &driver_version = "0.9.0.0");
 
@@ -119,6 +120,8 @@ public:
   static int GetPingFrameInterval(const ConnPropertyMap &connPropertyMap);
 
   static int GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap);
+
+  static int GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap);
 };
 } // namespace flight_sql
 } // namespace driver

--- a/flight_sql/flight_sql_connection.h
+++ b/flight_sql/flight_sql_connection.h
@@ -65,8 +65,8 @@ public:
   static const std::string CHUNK_BUFFER_CAPACITY;
   static const std::string HIDE_SQL_TABLES_LISTING;
   static const std::string SEND_PING_FRAME;
-  static const std::string PING_FRAME_INTERVAL;
-  static const std::string PING_FRAME_TIMEOUT;
+  static const std::string PING_FRAME_INTERVAL_MS;
+  static const std::string PING_FRAME_TIMEOUT_MS;
   static const std::string MAX_PINGS_WITHOUT_DATA;
 
   explicit FlightSqlConnection(odbcabstraction::OdbcVersion odbc_version, const std::string &driver_version = "0.9.0.0");
@@ -120,9 +120,9 @@ public:
 
   static bool GetSendPingFrame(const ConnPropertyMap &connPropertyMap);
 
-  static boost::optional<int> GetPingFrameInterval(const ConnPropertyMap &connPropertyMap);
+  static boost::optional<int> GetPingFrameIntervalMilliseconds(const ConnPropertyMap &connPropertyMap);
 
-  static boost::optional<int> GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap);
+  static boost::optional<int> GetPingFrameTimeoutMilliseconds(const ConnPropertyMap &connPropertyMap);
 
   static boost::optional<int> GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap);
 };

--- a/flight_sql/flight_sql_connection.h
+++ b/flight_sql/flight_sql_connection.h
@@ -117,11 +117,11 @@ public:
 
   static bool GetSendPingFrame(const ConnPropertyMap &connPropertyMap);
 
-  static int GetPingFrameInterval(const ConnPropertyMap &connPropertyMap);
+  static boost::optional<int> GetPingFrameInterval(const ConnPropertyMap &connPropertyMap);
 
-  static int GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap);
+  static boost::optional<int> GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap);
 
-  static int GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap);
+  static boost::optional<int> GetMaxPingsWithoutData(const ConnPropertyMap &connPropertyMap);
 };
 } // namespace flight_sql
 } // namespace driver

--- a/flight_sql/flight_sql_connection.h
+++ b/flight_sql/flight_sql_connection.h
@@ -63,6 +63,9 @@ public:
   static const std::string USE_WIDE_CHAR;
   static const std::string CHUNK_BUFFER_CAPACITY;
   static const std::string HIDE_SQL_TABLES_LISTING;
+  static const std::string SEND_PING_FRAME;
+  static const std::string PING_FRAME_INTERVAL;
+  static const std::string PING_FRAME_TIMEOUT;
 
   explicit FlightSqlConnection(odbcabstraction::OdbcVersion odbc_version, const std::string &driver_version = "0.9.0.0");
 
@@ -110,6 +113,12 @@ public:
   size_t GetChunkBufferCapacity(const ConnPropertyMap &connPropertyMap);
 
   bool GetHideSQLTablesListing(const ConnPropertyMap &connPropertyMap);
+
+  static bool GetSendPingFrame(const ConnPropertyMap &connPropertyMap);
+
+  static int GetPingFrameInterval(const ConnPropertyMap &connPropertyMap);
+
+  static int GetPingFrameTimeout(const ConnPropertyMap &connPropertyMap);
 };
 } // namespace flight_sql
 } // namespace driver


### PR DESCRIPTION
With these changes, which are turned off by default, a user can configure the behavior of driver originated PING frames via Connection Properties. 

The feature can be turned on and the time intervals can be configured via Connection Properties.

New Connection Properties and their default values:

1. SendPingFrame, `boolean`, defaults to`false`. Enables/disables sending ping frames during idle periods
3. PingFrameIntervalMilliseconds, `int`, defaults to 2 hours. Interval between successive ping frames. Unit is milliseconds.
4. PingFrameTimeoutMilliseconds, `int`, defaults to 20 seconds. Timeout for receiving a pong frame after sending a ping frame. Unit is milliseconds.
5. MaxPingsWithoutData, `int`: defaults to 2. Max number of ping frames to send during an idle period


